### PR TITLE
fixing issue with download links for QA data

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,9 +36,6 @@
 							<a class="nav-link js-scroll-trigger" href="#ranking">Passage Ranking</a>
 						</li>
 						<li class="nav-item">
-							<a class="nav-link js-scroll-trigger" href="#retirement">DataSet Retirement</a>
-						</li>
-						<li class="nav-item">
 							<a class="nav-link js-scroll-trigger" href="#updates">Updates</a>
 						</li>
 						<li class="nav-item">
@@ -105,10 +102,9 @@
 						<a style="background-color:#000000;border-color:#000000;" class="btn btn-primary btn-md mb-4 mr-2" href="https://arxiv.org/pdf/2006.05324.pdf">ORCAS Dataset</a>
 						<a style="background-color:#000000;border-color:#000000;" class="btn btn-primary btn-md mb-4 mr-2" href="https://github.com/microsoft/TREC-2020-Deep-Learning">TREC 2020 Deep Learning</a>
 						<a style="background-color:#000000;border-color:#000000;" class="btn btn-primary btn-md mb-4 mr-2" href="https://github.com/microsoft/TREC-2019-Deep-Learning">TREC 2019 Deep Learning</a><br/>
-
-                                                <iframe src="https://microsoft.github.io/MSMARCO-Document-Ranking-Submissions/leaderboard/" title="Document Ranking Leaderboard" width="100%" height="512" border="0" frameBorder="0"></iframe>
-
-                                                <a href="https://microsoft.github.io/MSMARCO-Document-Ranking-Submissions/leaderboard/">Link to full leaderboard</a>
+						<div id="docrankingdata"> </div>
+						<iframe src="https://microsoft.github.io/MSMARCO-Document-Ranking-Submissions/leaderboard/" title="Document Ranking Leaderboard" width="100%" height="512" border="0" frameBorder="0"></iframe>
+						<a href="https://microsoft.github.io/MSMARCO-Document-Ranking-Submissions/leaderboard/">Link to full leaderboard</a>
 						</div>
 					
 					</div>
@@ -139,7 +135,6 @@
 						<a style="background-color:#000000;border-color:#000000;" class="btn btn-primary btn-md mb-4 mr-2" href="https://github.com/microsoft/TREC-2019-Deep-Learning">TREC 2019 Deep Learning</a>
 						<h3>Dataset Download links</h3>
 						<div id="rankingdata"> </div>
-					
 						<h4>Passage Ranking Leaderboard(10/26/2018-Present) ranked by MRR on Eval</h4>
 						<div class="table-responsive">
 							<table class="table table-striped" id='passagerankingtable'>


### PR DESCRIPTION
loading of datasets was broken because the div which document ranking data is injected into was removed. I have added it back, formated some spacing issues, and removed dataset retirement link in the menu. 

